### PR TITLE
githubメンションお知らせをいろいろ調整

### DIFF
--- a/scripts/notify-github-mentioned.coffee
+++ b/scripts/notify-github-mentioned.coffee
@@ -13,11 +13,12 @@
 #   "moment": "^2.20.1"
 #
 # Commands:
-#   hubot mention_check - 昨日から今までのメンションをお知らせ
+#   hubot mention_check user_id - 昨日から今までのメンションをお知らせ
 
 GitHubApi = require 'github'
 moment = require 'moment'
 {CronJob} = require 'cron'
+moment.locale('ja')
 
 github = new GitHubApi
 
@@ -25,46 +26,53 @@ github.authenticate
   type: 'token'
   token: process.env.GITHUB_TOKEN
 
-fetchEvents = -> new Promise (resolve, reject) ->
+fetchEvents = ({per_page})-> new Promise (resolve, reject) ->
   github.issues.getEventsForRepo
     owner: process.env.REPO_OWNER
     repo: process.env.REPO_NAME
-    per_page: 300
+    per_page: per_page or 30
   .then (result) ->
     resolve result
   .catch (result) ->
     reject result
 
-start = (res)->
-
 module.exports = (robot) ->
 
 
-  robot.respond /mention_check/i, (res) ->
-    yeasterday = moment().subtract(1, 'day')
-    res.send "#{yeasterday.format('M月D日HH時mm分')}以降のメンションをチェックします...."
-    fetchEvents().then (messages) ->
+  robot.respond /mention_check (.+)/i, (res) ->
+    name = res.match[1]
+    yesterday = moment().subtract(1, 'day')
+    res.send "#{yesterday.format('M月D日(ddd)HH時mm分')}以降の#{name}あてメンションをチェックします...."
+
+    fetchEvents(per_page: 200).then (messages) ->
       mentioned = messages.data
         .filter(({event})-> event is 'mentioned')
-        .filter(({created_at})-> yeasterday.isBefore created_at)
+        .filter(({created_at})-> yesterday.isBefore created_at)
+        .filter(({actor})-> actor.login.toLowerCase() is name.toLowerCase())
         .map (d)->
-          "@#{d.actor.login} #{d.issue.html_url}  (#{moment(d.created_at).format('YYYY-MM-DD HH:mm')}) "
+          "@#{d.actor.login} #{d.issue.html_url}  (#{moment(d.created_at).format('MM月DD日(ddd)HH時mm分')}) "
       res.send 'ないよ' if mentioned.length is 0
       mentioned.forEach (m)-> res.send m
     .catch (e) ->
       res.send "失敗しました"
       console.error e
 
-  lastFetched = moment().subtract(1, 'day')
+  brainKey = 'last_fetched_github_mention'
 
-  new CronJob '0 0,30 10-19 * * 1-5', ->
-    fetchEvents().then (messages) ->
+  # 10分おきに起動
+  new CronJob '0 0,10,20,30,40,50 * * * *', ->
+    rawLastFetched = robot.brain.get(brainKey) ? moment().subtract(1, 'hour').format()
+    lastFetched = moment(rawLastFetched)
+
+    # フェッチ時間を保存
+    robot.brain.set brainKey, moment().format()
+
+    fetchEvents(per_page: 50).then (messages) ->
       mentioned = messages.data
         .filter(({event})-> event is 'mentioned')
         .filter(({created_at})-> lastFetched.isBefore created_at)
         .map (d)->
-          "@#{d.actor.login} check #{d.issue.html_url} (#{moment(d.created_at).format('YYYY-MM-DD HH:mm')}) "
-      lastFetched = moment()
+          "@#{d.actor.login} :eye: #{d.issue.html_url} :watch: (#{moment(d.created_at).format('M月D日(ddd)HH時mm分')}) "
       mentioned.forEach (m)-> robot.messageRoom process.env.DEVELOPER_ROOM_NAME, m
   , null, true
 


### PR DESCRIPTION
- 引数あてのメンションだけを表示する( `neko mention_check oieioi` とか)
- 10分起きにチェックするように cron の時間を変更した
- 夜nekoが死んだ時ように前回のフェッチ時間を robot.brain に保持する